### PR TITLE
Inline homepage intro; fix timeline default selection

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,7 @@ subtitle: "Unreal Engine Gameplay Developer"
 layout: "homepage"
 profile_image: "/images/LDW-logo-blackbg.png"
 highlighted_text: "Hi! I’m Ldwork"
-intro_text: "Indie game developer from Vietnam."
+intro_text: "An indie game developer from Vietnam."
 tags: ["All", "Unity", "Unreal Engine", "Personal", "Work", "Prototype"]
 email: ldwork.cs@gmail.com
 phone: +84 769 661 420

--- a/layouts/page/homepage.html
+++ b/layouts/page/homepage.html
@@ -37,8 +37,10 @@
 
     <section class="intro">
         <img src="{{ .Params.profile_image }}" alt="LDW logo" class="profile-pic">
-        <h2 class="highlighted-text">{{ .Params.highlighted_text }}</h2>
-        <p class="intro-text">{{ .Params.intro_text }}</p>
+        <div class="intro-text-block">
+            <h2 class="highlighted-text">{{ .Params.highlighted_text }}</h2>
+            <p class="intro-text">{{ .Params.intro_text }}</p>
+        </div>
     </section>
 
     {{ partial "floating_nav.html" . }}

--- a/public/css/homepage.css
+++ b/public/css/homepage.css
@@ -33,19 +33,25 @@
 
 /* Intro section */
 .intro {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 28px;
     margin-top: 50px;
 }
 
 .profile-pic {
-    width: 100%;
-    max-width: 120px;
-    height: auto;
+    width: 120px;
+    height: 120px;
     aspect-ratio: 1 / 1;
     border-radius: 50%;
     object-fit: cover;
     display: block;
-    margin: 0 auto;
+    flex-shrink: 0;
+}
+
+.intro-text-block {
+    text-align: left;
 }
 
 .highlighted-text {
@@ -55,6 +61,7 @@
     position: relative;
     display: inline-block;
     padding: 5px 10px;
+    margin: 0 0 6px;
 }
 
 .highlighted-text::before {
@@ -73,10 +80,19 @@
     font-family: sans-serif, sans-serif;
     font-size: 16px;
     color: #111111;
-    width: 80%;
-    max-width: 600px;
-    margin: 0px auto;
+    max-width: 520px;
+    margin: 0;
     line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+    .intro {
+        flex-direction: column;
+        text-align: center;
+    }
+    .intro-text-block {
+        text-align: center;
+    }
 }
 
 /* Tag filter row above the project grid */

--- a/public/index.html
+++ b/public/index.html
@@ -5,13 +5,13 @@
     <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Ldwork</title>
-<meta name="description" content="Indie game developer from Vietnam.">
+<meta name="description" content="An indie game developer from Vietnam.">
 <link rel="canonical" href="http://localhost:1313/">
 
 
 <meta property="og:site_name" content="Ldwork">
 <meta property="og:title" content="Ldwork">
-<meta property="og:description" content="Indie game developer from Vietnam.">
+<meta property="og:description" content="An indie game developer from Vietnam.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="http://localhost:1313/">
 <meta property="og:image" content="http://localhost:1313/images/LDW-logo-blackbg.png">
@@ -19,7 +19,7 @@
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Ldwork">
-<meta name="twitter:description" content="Indie game developer from Vietnam.">
+<meta name="twitter:description" content="An indie game developer from Vietnam.">
 <meta name="twitter:image" content="http://localhost:1313/images/LDW-logo-blackbg.png">
 
 
@@ -55,8 +55,10 @@
 
     <section class="intro">
         <img src="/images/LDW-logo-blackbg.png" alt="LDW logo" class="profile-pic">
-        <h2 class="highlighted-text">Hi! I’m Ldwork</h2>
-        <p class="intro-text">Indie game developer from Vietnam.</p>
+        <div class="intro-text-block">
+            <h2 class="highlighted-text">Hi! I’m Ldwork</h2>
+            <p class="intro-text">An indie game developer from Vietnam.</p>
+        </div>
     </section>
 
     

--- a/public/js/timeline.js
+++ b/public/js/timeline.js
@@ -186,24 +186,37 @@
         bar.addEventListener("click", () => applyBar(bar));
     });
 
-    // Default: pick the role active today. An ongoing role is always considered
-    // current (its yaml `end` is just an axis hint). Among non-ongoing roles,
-    // "active" means today falls within [start, end]. If multiple match, prefer
-    // the one with the latest start. Fall back to the latest-ending bar.
+    // Default precedence: ongoing role first (yaml-flagged `ongoing: true`,
+    // even if its start is in the future), then the role active today
+    // (today within [start, end]), then the latest-ending bar. When multiple
+    // candidates tie at a step, prefer the latest start.
     let defaultBar = bars[0];
     let bestStart = -Infinity;
     let found = false;
+
     bars.forEach((bar) => {
+        if (bar.dataset.ongoing !== "true") return;
         const s = startIdx(bar.dataset.start);
-        const e = endIdx(bar.dataset.end);
-        const isOngoing = bar.dataset.ongoing === "true";
-        const isActive = isOngoing ? s <= presentIdx : s <= presentIdx && presentIdx < e;
-        if (isActive && s > bestStart) {
+        if (s > bestStart) {
             bestStart = s;
             defaultBar = bar;
             found = true;
         }
     });
+
+    if (!found) {
+        bars.forEach((bar) => {
+            const s = startIdx(bar.dataset.start);
+            const e = endIdx(bar.dataset.end);
+            const isActive = s <= presentIdx && presentIdx < e;
+            if (isActive && s > bestStart) {
+                bestStart = s;
+                defaultBar = bar;
+                found = true;
+            }
+        });
+    }
+
     if (!found) {
         let bestEnd = -Infinity;
         bestStart = -Infinity;
@@ -217,5 +230,6 @@
             }
         });
     }
+
     applyBar(defaultBar);
 })();

--- a/static/css/homepage.css
+++ b/static/css/homepage.css
@@ -33,19 +33,25 @@
 
 /* Intro section */
 .intro {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 28px;
     margin-top: 50px;
 }
 
 .profile-pic {
-    width: 100%;
-    max-width: 120px;
-    height: auto;
+    width: 120px;
+    height: 120px;
     aspect-ratio: 1 / 1;
     border-radius: 50%;
     object-fit: cover;
     display: block;
-    margin: 0 auto;
+    flex-shrink: 0;
+}
+
+.intro-text-block {
+    text-align: left;
 }
 
 .highlighted-text {
@@ -55,6 +61,7 @@
     position: relative;
     display: inline-block;
     padding: 5px 10px;
+    margin: 0 0 6px;
 }
 
 .highlighted-text::before {
@@ -73,10 +80,19 @@
     font-family: sans-serif, sans-serif;
     font-size: 16px;
     color: #111111;
-    width: 80%;
-    max-width: 600px;
-    margin: 0px auto;
+    max-width: 520px;
+    margin: 0;
     line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+    .intro {
+        flex-direction: column;
+        text-align: center;
+    }
+    .intro-text-block {
+        text-align: center;
+    }
 }
 
 /* Tag filter row above the project grid */

--- a/static/js/timeline.js
+++ b/static/js/timeline.js
@@ -186,24 +186,37 @@
         bar.addEventListener("click", () => applyBar(bar));
     });
 
-    // Default: pick the role active today. An ongoing role is always considered
-    // current (its yaml `end` is just an axis hint). Among non-ongoing roles,
-    // "active" means today falls within [start, end]. If multiple match, prefer
-    // the one with the latest start. Fall back to the latest-ending bar.
+    // Default precedence: ongoing role first (yaml-flagged `ongoing: true`,
+    // even if its start is in the future), then the role active today
+    // (today within [start, end]), then the latest-ending bar. When multiple
+    // candidates tie at a step, prefer the latest start.
     let defaultBar = bars[0];
     let bestStart = -Infinity;
     let found = false;
+
     bars.forEach((bar) => {
+        if (bar.dataset.ongoing !== "true") return;
         const s = startIdx(bar.dataset.start);
-        const e = endIdx(bar.dataset.end);
-        const isOngoing = bar.dataset.ongoing === "true";
-        const isActive = isOngoing ? s <= presentIdx : s <= presentIdx && presentIdx < e;
-        if (isActive && s > bestStart) {
+        if (s > bestStart) {
             bestStart = s;
             defaultBar = bar;
             found = true;
         }
     });
+
+    if (!found) {
+        bars.forEach((bar) => {
+            const s = startIdx(bar.dataset.start);
+            const e = endIdx(bar.dataset.end);
+            const isActive = s <= presentIdx && presentIdx < e;
+            if (isActive && s > bestStart) {
+                bestStart = s;
+                defaultBar = bar;
+                found = true;
+            }
+        });
+    }
+
     if (!found) {
         let bestEnd = -Infinity;
         bestStart = -Infinity;
@@ -217,5 +230,6 @@
             }
         });
     }
+
     applyBar(defaultBar);
 })();


### PR DESCRIPTION
## Summary
- Lay out the homepage profile pic and intro copy side-by-side, stacking back to centered on screens under 640px. Updated `content/_index.md`, `layouts/page/homepage.html`, `public/index.html`, and both `public/`/`static/` copies of `homepage.css`.
- Reworded intro to "An indie game developer from Vietnam." (also updated in the prerendered meta tags).
- Timeline default-bar selection now prefers any `ongoing: true` role first (even if its start is in the future), then a role active today, then the latest-ending bar. Applied to both `public/js/timeline.js` and `static/js/timeline.js`.

## Test plan
- [ ] Load homepage; logo + heading + blurb sit on one row at desktop width
- [ ] Resize below 640px; intro stacks back to centered layout
- [ ] Timeline auto-selects the ongoing role on load (even if its yaml `start` is in the future)
- [ ] Click any other bar; selection still applies normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)